### PR TITLE
make emoji customizable

### DIFF
--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -8,7 +8,16 @@
         "bot_user": {
             "display_name": "KlothoBot",
             "always_online": true
-        }
+        },
+        "slash_commands": [
+            {
+                "command": "/github-notifications",
+                "url": "https://example.com/YOUR ENDPOINT HERE/slack",
+                "description": "Configures GitHub notifications",
+                "usage_hint": "emoji [:tada:]",
+                "should_escape": false
+            }
+        ]
     },
     "oauth_config": {
         "scopes": {
@@ -16,7 +25,8 @@
                 "chat:write",
                 "chat:write.customize",
                 "channels:read",
-                "groups:read"
+                "groups:read",
+                "commands"
             ]
         }
     },
@@ -28,6 +38,10 @@
                 "group_left",
                 "member_joined_channel"
             ]
+        },
+        "interactivity": {
+            "is_enabled": true,
+            "request_url": "https://example.com/YOUR ENDPOINT HERE/slack"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1,0 +1,68 @@
+/*
+ * @klotho::persist {
+ *   id = "emoji"
+ * }
+ */
+let emojiStore = new Map<EmojiKey, string>()
+
+export class EmojiStore {
+    private readonly backing: Map<EmojiKey, string>
+    
+    static real(): EmojiStore {
+        return new EmojiStore(emojiStore)
+    }
+
+    static test(): EmojiStore {
+        return new EmojiStore(new Map())
+    }
+
+    private constructor(backing: Map<EmojiKey, string>) {
+        this.backing = backing
+    }
+
+    async set(key: EmojiKey, value: string) {
+        await this.backing.set(key, value)
+    }
+
+    async get(key: EmojiKey): Promise<string> {
+        let resolved = await this.backing.get(key)
+        if (resolved === undefined) {
+            resolved = EmojiStore.defaultEmoji[key]
+        }
+        if (resolved === undefined) {
+            resolved = ':robot_face:'
+        }
+        return resolved
+    }
+
+    private static readonly defaultEmoji: EmojiValues = {
+        pr_opened: ':eight_pointed_black_star:',
+        pr_merged: ':rocket:',
+        pr_closed: ':x:',
+        pr_draft: ':see_no_evil:',
+        comment_approved: ':white_check_mark:',
+        comment_changes_requested: ':exclamation:',
+        comment_posted: ':speech_balloon:',
+    }
+}
+
+export type PrEmoji = 'opened' | 'merged' | 'closed' | 'draft'
+export type CommentEmoji = 'approved' | 'changes_requested' | 'posted'
+
+export type EmojiKey =
+    | `pr_${PrEmoji}`
+    | `comment_${CommentEmoji}`
+
+type EmojiValues = {
+    [Key in EmojiKey]: string
+}
+
+export const emojiDescriptions: EmojiValues = {
+    pr_opened: "Pull request opened",
+    pr_merged: "Pull request merged",
+    pr_closed: "Pull request closed without merging",
+    pr_draft: "Pull request converted to draft",
+    comment_approved: "Pull request approved",
+    comment_changes_requested: "Pull request had changes requested",
+    comment_posted: "Pull request had comments",
+} as const

--- a/src/slack-commands.ts
+++ b/src/slack-commands.ts
@@ -41,7 +41,7 @@ export function parseEmojiCommand(command: String): {image: string} | {err: stri
     if (fullLine === null) {
         return {err: "Unrecognized command"} // not expected!
     }
-    if ((fullLine.groups?.extra)?.length > 0) {
+    if ((fullLine.groups?.extra ?? "").length > 0) {
         return {err: "Command may contain one optional `:image:`, and nothing else."}
     }
     if (fullLine.groups?.images === undefined) {

--- a/src/slack-commands.ts
+++ b/src/slack-commands.ts
@@ -10,29 +10,23 @@ import {PlainTextOption} from "@slack/types";
 
 type Action = DialogSubmitAction | WorkflowStepEdit | InteractiveAction | BlockElementAction
 
-export async function handleAction(action: Action): Promise<ActionResult | undefined> {
+export async function handleConfigureEmojiAction(action: Action): Promise<ConfigureEmojiResult | undefined> {
     if (action.type === 'static_select') {
-        if (action.action_id === 'configure_emoji') {
-            const newEmoji = action.block_id
-            const forWhich = action.selected_option.value as EmojiKey
-            await EmojiStore.real().set(forWhich, newEmoji)
-            return {
-                type: "configure_emoji",
-                newValue: newEmoji,
-            }
+        const newEmoji = action.block_id
+        const forWhich = action.selected_option.value as EmojiKey
+        await EmojiStore.real().set(forWhich, newEmoji)
+        return {
+            emoji: forWhich,
+            image: newEmoji,
         }
     } else {
         console.log("unknown action: ", action.type)
     }
-    return
 }
 
-type ActionResult =
-    | ConfigureEmojiResult
-
-interface ConfigureEmojiResult {
-    type: 'configure_emoji'
-    newValue: string,
+export interface ConfigureEmojiResult {
+    emoji: EmojiKey,
+    image: string,
 }
 
 /**
@@ -47,7 +41,7 @@ export function parseEmojiCommand(command: String): {image: string} | {err: stri
     if (fullLine === null) {
         return {err: "Unrecognized command"} // not expected!
     }
-    if ((fullLine.groups?.extra ?? "").length > 0) {
+    if ((fullLine.groups?.extra)?.length > 0) {
         return {err: "Command may contain one optional `:image:`, and nothing else."}
     }
     if (fullLine.groups?.images === undefined) {

--- a/src/slack-commands.ts
+++ b/src/slack-commands.ts
@@ -1,0 +1,151 @@
+import {
+    BlockElementAction,
+    DialogSubmitAction,
+    InteractiveAction,
+    RespondArguments,
+    WorkflowStepEdit,
+} from "@slack/bolt";
+import {emojiDescriptions, EmojiKey, EmojiStore} from "./emoji";
+import {PlainTextOption} from "@slack/types";
+
+type Action = DialogSubmitAction | WorkflowStepEdit | InteractiveAction | BlockElementAction
+
+export async function handleAction(action: Action): Promise<ActionResult | undefined> {
+    if (action.type === 'static_select') {
+        if (action.action_id === 'configure_emoji') {
+            const newEmoji = action.block_id
+            const forWhich = action.selected_option.value as EmojiKey
+            await EmojiStore.real().set(forWhich, newEmoji)
+            return {
+                type: "configure_emoji",
+                newValue: newEmoji,
+            }
+        }
+    } else {
+        console.log("unknown action: ", action.type)
+    }
+    return
+}
+
+type ActionResult =
+    | ConfigureEmojiResult
+
+interface ConfigureEmojiResult {
+    type: 'configure_emoji'
+    newValue: string,
+}
+
+/**
+ * Parses a command that starts with "emoji".
+ *
+ * The command must either be just "emoji", or else contain 1 or more images of the form ":image:". It may not contain
+ * anything else.
+ * @param command
+ */
+export function parseEmojiCommand(command: String): {image: string} | {err: string} | 'describe' {
+    const fullLine = command.match(/^emoji(?:\s+(?<images>:[^:]+:)?\s*(?<extra>.*))?/)
+    if (fullLine === null) {
+        return {err: "Unrecognized command"} // not expected!
+    }
+    if ((fullLine.groups?.extra ?? "").length > 0) {
+        return {err: "Command may contain one optional `:image:`, and nothing else."}
+    }
+    if (fullLine.groups?.images === undefined) {
+        return 'describe'
+    }
+    return {image: fullLine.groups?.images}
+}
+
+export async function describeCurrentEmoji(commandName: string): Promise<string> {
+    const emojiStore = EmojiStore.real()
+    const currentImages = forEachEmojiInOrder((key) => {
+        const image = emojiStore.get(key)
+        const description = emojiDescriptions[key]
+        return {image: image, description: description}
+    })
+    let result = "*Current emoji:*\n\n"
+    for (const {image, description} of currentImages) {
+        result += `${await image} ${description}\n`
+    }
+    result += `\nTo change one, do: \`${commandName} emoji :new-emoji:\``
+    return result
+}
+
+export async function handleSlashCommand(commandName: string, commandText: string): Promise<string | RespondArguments> {
+    if (commandText.match(/^emoji\b/)) {
+        const commandParse = parseEmojiCommand(commandText)
+        if (commandParse === 'describe') {
+            return {
+                text: await describeCurrentEmoji(commandName),
+                mrkdwn: true,
+            }
+        }
+        if ('err' in commandParse) {
+            return {
+                text: `${commandParse.err}`,
+                mrkdwn: false,
+            }
+        }
+        const ghEventOptions: PlainTextOption[] = forEachEmojiInOrder((key) => {
+            return {
+                text: {
+                    type: 'plain_text',
+                    text: emojiDescriptions[key]
+                },
+                value: key,
+            }
+        })
+        return {
+            blocks: [
+                {
+                    type: 'section',
+                    text: {
+                        type: 'mrkdwn',
+                        text: emojiConfigurePrompt(commandParse.image),
+                    },
+                    accessory: {
+                        type: 'static_select',
+                        placeholder: {
+                            type: 'plain_text',
+                            text: 'Select an event',
+                        },
+                        options: ghEventOptions,
+                        action_id: "configure_emoji",
+                    },
+                    block_id: commandParse.image,
+                }
+            ],
+        }
+    } else {
+        return {
+            text: `Unrecognized command.\nTry \`/${commandName} emoji :<emoji>:\` to configure the emoji for GitHub actions.\nFor example:\n>/${commandName} emoji :rocket:`,
+            mrkdwn: true,
+        }
+    }
+}
+
+export function emojiConfigurePrompt(newImage: string): string {
+    return `Set which GitHub event to use for ${newImage}`
+}
+
+const emojiKeyOrdering: { [key in EmojiKey]: number } = {
+    "pr_opened": 0,
+    "pr_merged": 1,
+    "pr_closed": 2,
+    "pr_draft": 3,
+    "comment_approved": 4,
+    "comment_changes_requested": 4,
+    "comment_posted": 5,
+} as const
+
+function forEachEmojiInOrder<T>(fn: (key: EmojiKey) => T): T[] {
+    let results: {key: number, result: T}[] = []
+    for (const key in emojiKeyOrdering) {
+        const emojiKey = key as EmojiKey
+        results.push({key: emojiKeyOrdering[emojiKey], result: fn(emojiKey)})
+    }
+    results.sort((a, b) => {
+        return a.key - b.key
+    })
+    return results.map(r => r.result)
+}

--- a/src/slack-listener.ts
+++ b/src/slack-listener.ts
@@ -203,6 +203,8 @@ const simple = new SimpleReceiver((bolt) => {
     // The command name itself is configured within the Slack app settings (https://api.slack.com/apps/), and is out
     // of our control in this code base.
     //
+    // If you use the manifest defined in slack-app-manifest.json, this will be `/github-notifications` by default.
+    //
     // In other words, even though we accept any command, we actually expect that there'll just be a single command
     // that always gets used for any given instance of this app. We just don't know what it is.
     //

--- a/test/emoji.test.ts
+++ b/test/emoji.test.ts
@@ -1,0 +1,19 @@
+import {emojiDescriptions, EmojiStore} from '../src/emoji'
+
+test('get defaulted value', async () => {
+    const store = EmojiStore.test()
+    const emoji = await store.get('pr_draft')
+    expect(emoji).toBe(':see_no_evil:')
+})
+
+test('get set value', async () => {
+    const store = EmojiStore.test()
+    await store.set('pr_draft', ':my-whatever-emoji:')
+    const emoji = await store.get('pr_draft')
+    expect(emoji).toBe(':my-whatever-emoji:')
+})
+
+test('emoji description', async () => {
+    const description = emojiDescriptions['pr_closed']
+    expect(description).toBe('Pull request closed without merging')
+})

--- a/test/slack-commands.test.ts
+++ b/test/slack-commands.test.ts
@@ -1,0 +1,83 @@
+import {handleSlashCommand, parseEmojiCommand} from '../src/slack-commands'
+
+
+test.each([
+    {given: "emoji", want: 'describe'},
+    {given: "emoji :foo:", want: {image: ":foo:"}},
+    {given: "emoji :foo: :bar:", want: {err: "Command may contain one optional `:image:`, and nothing else."}},
+    {given: "emoji junk", want: {err: "Command may contain one optional `:image:`, and nothing else."}},
+    {given: "emoji :foo: :bar: junk", want: {err: "Command may contain one optional `:image:`, and nothing else."}},
+])("'emoji' parse: %s", ({given, want}) => {
+    const actual = parseEmojiCommand(given)
+    expect(actual).toEqual(want)
+})
+
+test("describe all emoji", async () => {
+    const actual = await handleSlashCommand("/myklotho", "emoji")
+    const expectedString = [
+        '*Current emoji:*',
+        '',
+        ':eight_pointed_black_star: Pull request opened',
+        ':rocket: Pull request merged',
+        ':x: Pull request closed without merging',
+        ':see_no_evil: Pull request converted to draft',
+        ':white_check_mark: Pull request approved',
+        ':exclamation: Pull request had changes requested',
+        ':speech_balloon: Pull request had comments',
+        '',
+        'To change one, do: `/myklotho emoji :new-emoji:`',
+    ].join("\n")
+    expect(actual).toEqual({
+        mrkdwn: true,
+        text: expectedString,
+    })
+})
+
+test("configure :hat:", async () => {
+    const actual = await handleSlashCommand("/test", "emoji :hat:")
+    const want = {
+        blocks: [
+            expectedEmojiOptionsMenu({forEmoji: ':hat:'}),
+        ],
+    };
+    expect(actual).toEqual(want)
+})
+
+function expectedEmojiOptionsMenu(options: {forEmoji: string}) {
+    const menuOptions = [
+        ['pr_opened', 'Pull request opened'],
+        ['pr_merged', 'Pull request merged'],
+        ['pr_closed', 'Pull request closed without merging'],
+        ['pr_draft', 'Pull request converted to draft'],
+        ['comment_approved', 'Pull request approved'],
+        ['comment_changes_requested', 'Pull request had changes requested'],
+        ['comment_posted', 'Pull request had comments'],
+    ]
+    const optionBlocks = menuOptions.map(o => {
+        return {
+            value: o[0],
+            text: {
+                type: "plain_text",
+                text: o[1]
+            },
+        }
+    })
+    return {
+        accessory: {
+            action_id: "configure_emoji",
+            options: optionBlocks,
+            placeholder: {
+                text: "Select an event",
+                type: "plain_text"
+            },
+            type: "static_select"
+        },
+        block_id: options.forEmoji,
+        text: {
+            text: `Set which GitHub event to use for ${options.forEmoji}`,
+            type: "mrkdwn"
+        },
+        type: "section"
+    }
+}
+


### PR DESCRIPTION
This involves two main steps: first, making an EmojiStore to record which emoji we want for each action; and second, adding slack commands and actions for setting these.

As part of this, I'm also changing the default emoji to standards ones. This makes it work out of the box for people installing it without our custom emoji.

Resolves #37