### PR TITLE
better failure text

### DIFF
--- a/src/slack-commands.ts
+++ b/src/slack-commands.ts
@@ -112,8 +112,24 @@ export async function handleSlashCommand(commandName: string, commandText: strin
         }
     } else {
         return {
-            text: `Unrecognized command.\nTry \`/${commandName} emoji :<emoji>:\` to configure the emoji for GitHub actions.\nFor example:\n>/${commandName} emoji :rocket:`,
-            mrkdwn: true,
+            blocks: [
+                {
+                    type: 'section',
+                    text: {
+                        type: 'mrkdwn',
+                        text: `Unrecognized command.\nTry \`${commandName} emoji :<emoji>:\` to configure the emoji for GitHub actions.\nFor example:\n>${commandName} emoji :rocket:`,
+                    },
+                },
+                {
+                    type: 'context',
+                    elements: [
+                        {
+                            type: 'plain_text',
+                            text: `Failed command: ${commandName} ${commandText}`,
+                        }
+                    ]
+                },
+            ]
         }
     }
 }


### PR DESCRIPTION
1. Remove the double-slashing: we were reporting the command as `//foo` instead of `/foo`
2. Add the failed command as context

As of main:

![before this change](https://user-images.githubusercontent.com/110620369/195691682-a1a54f1e-6f8c-4ffd-9d37-9361f43898fe.png)

![after the change: double slashes are removed, and we echo back the failed command](https://user-images.githubusercontent.com/110620369/195692260-bcf0a7eb-712a-4dbe-9e1f-85167f28a543.png)
