### PR TITLE
use only a single exec unit

### DIFF
--- a/lib/npm_scripts/klotho
+++ b/lib/npm_scripts/klotho
@@ -7,5 +7,5 @@ if [[ ! -d node_modules ]]; then
 fi
 npm test
 npx tsc
-klotho dist --strict --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+klotho dist --strict --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR" -p aws
 npm --prefix "$KLOTHO_OUT_DIR" install

--- a/src/github-listener.ts
+++ b/src/github-listener.ts
@@ -1,9 +1,3 @@
-/**
- * @klotho::execution_unit {
- *   id = "github-listener"
- * }
- */
-
 import express = require('express')
 import { Slack } from './slack'
 import { IssueCommentEvent, PingEvent, PullRequestEvent } from "@octokit/webhooks-types";

--- a/src/slack-listener.ts
+++ b/src/slack-listener.ts
@@ -1,9 +1,3 @@
-/**
- * @klotho::execution_unit {
- *   id = "slack-listener"
- * }
- */
-
 import express = require('express')
 import * as SlackBolt from '@slack/bolt'
 import { WebClient } from '@slack/web-api'


### PR DESCRIPTION
Also, fix up the `npm run klotho` script to include the provider, which is now required.